### PR TITLE
Replace base64 with cl-base64

### DIFF
--- a/sha1.asd
+++ b/sha1.asd
@@ -11,4 +11,4 @@
   :description "SHA1 Digest and HMAC for LispWorks."
   :serial t
   :components ((:file "sha1"))
-  :depends-on ("base64"))
+  :depends-on ("cl-base64"))

--- a/sha1.lisp
+++ b/sha1.lisp
@@ -18,7 +18,7 @@
 ;;;;
 
 (defpackage :sha1
-  (:use :cl :base64)
+  (:use :cl)
   (:export
    #:sha1-digest
    #:sha1-hex
@@ -162,7 +162,7 @@
 
 (defun sha1-base64 (message)
   "Return the SHA1 base64-encoded digest for a byte sequence."
-  (base64-encode (map 'string #'code-char (sha1-digest message))))
+  (base64:string-to-base64-string (map 'string #'code-char (sha1-digest message))))
 
 ;;; ----------------------------------------------------
 
@@ -200,4 +200,4 @@
 
 (defun hmac-sha1-base64 (key message)
   "Return the HMAC-SHA1 base64-encoded digest for a byte sequence."
-  (base64-encode (map 'string #'code-char (hmac-sha1-digest key message))))
+  (base64:string-to-base64-string (map 'string #'code-char (hmac-sha1-digest key message))))


### PR DESCRIPTION
`base64` is only used by this library while `cl-base64` is used by 23 others. It normally wouldn't be a problem but `cl-base64` uses `base64` as a nickname for its package so you can't load both `base64` and `cl-base64` in the same system. That's a huge problem because it means that you can't e.g. load `sha1` which depends on `base64` and `drakma` which depends on `cl-base64`.