### PR TITLE
Move from dependency base64 to cl-base64

### DIFF
--- a/sha1.asd
+++ b/sha1.asd
@@ -11,4 +11,4 @@
   :description "SHA1 Digest and HMAC for Common Lisp."
   :serial t
   :components ((:file "sha1"))
-  :depends-on ("base64"))
+  :depends-on ("cl-base64"))

--- a/sha1.lisp
+++ b/sha1.lisp
@@ -18,7 +18,7 @@
 ;;;;
 
 (defpackage :sha1
-  (:use :cl :base64)
+  (:use :cl :cl-base64)
   (:export
    #:sha1-digest
    #:sha1-hex
@@ -162,7 +162,7 @@
 
 (defun sha1-base64 (message)
   "Return the SHA1 base64-encoded digest for a byte sequence."
-  (base64-encode (map 'string #'code-char (sha1-digest message))))
+  (string-to-base64-string (map 'string #'code-char (sha1-digest message))))
 
 ;;; ----------------------------------------------------
 
@@ -200,4 +200,4 @@
 
 (defun hmac-sha1-base64 (key message)
   "Return the HMAC-SHA1 base64-encoded digest for a byte sequence."
-  (base64-encode (map 'string #'code-char (hmac-sha1-digest key message))))
+  (string-to-base64-string (map 'string #'code-char (hmac-sha1-digest key message))))


### PR DESCRIPTION
The official Quicklisp repository lists 51 libraries who depend on
cl-base64, while only 1 dependency who depends on base64 (sha1
excluded). Because both dependencies share the same package name
`base64`, no Lisp project can easily depend on sha1 if they already
depend on any of the other dependencies (or their dependencies, etc).
This commit moves sha1 to the larger group so that more programs can
depend on this codebase as well.

Ultimately, my goal here is moving a different project away from ironclad over to this library, because it only needs ironclad to do `sha1` hashes. Since *that* project uses `cl-base64` though, I won't be able to do that unless this project uses the same library (or cuts off base64 support entirely).