### PR TITLE
Replace base64 dependency with encoder function argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A very simple implementation of [SHA1](http://en.wikipedia.org/wiki/SHA-1) and [
 
 There are 6 functions exposed in the `sha1` package:
 
-    (sha1-digest message)            ;=> digest
-    (sha1-hex message)               ;=> string
-    (sha1-base64 message)            ;=> string
+    (sha1-digest message)                   ;=> digest
+    (sha1-hex message)                      ;=> string
+    (sha1-base64 message &optional encoder) ;=> string
 
-    (hmac-sha1-digest key message)   ;=> digest
-    (hmac-sha1-hex key message)      ;=> string
-    (hmac-sha1-base64 key message)   ;=> string
+    (hmac-sha1-digest key message)                   ;=> digest
+    (hmac-sha1-hex key message)                      ;=> string
+    (hmac-sha1-base64 key message &optional encoder) ;=> string
 
 A *digest* is a list of 20 bytes. The *-hex* functions will return a hexadecimal string that is equal to the digest. The *-base64* functions will return a base64-encoded string of the digest.
 
@@ -26,7 +26,9 @@ Some examples (from the Wikipedia pages):
     CL-USER > (sha1-hex "The quick brown fox jumps over the lazy dog")
     "2FD4E1C67A2D28FCED849EE1BB76E7391B93EB12"
 
-    CL-USER > (sha1-base64 "The quick brown fox jumps over the lazy dog")
+    CL-USER > (require :base64) ;; From massung/base64
+    CL-USER > (sha1-base64 "The quick brown fox jumps over the lazy dog"
+                           #'base64:base64-encode)
     "L9ThxnotKPzthJ7hu3bnORuT6xI="
 
     CL-USER > (hmac-sha1-hex "key" "The quick brown fox jumps over the lazy dog")

--- a/sha1.asd
+++ b/sha1.asd
@@ -10,5 +10,4 @@
   :license "Apache 2.0"
   :description "SHA1 Digest and HMAC for Common Lisp."
   :serial t
-  :components ((:file "sha1"))
-  :depends-on ("base64"))
+  :components ((:file "sha1")))

--- a/sha1.lisp
+++ b/sha1.lisp
@@ -18,7 +18,7 @@
 ;;;;
 
 (defpackage :sha1
-  (:use :cl :base64)
+  (:use :cl)
   (:export
    #:sha1-digest
    #:sha1-hex
@@ -30,6 +30,11 @@
    #:hmac-sha1-base64))
 
 (in-package :sha1)
+
+;;; ----------------------------------------------------
+
+(defvar *base64-encoder* nil
+  "SHA1-BASE64 and HMAC-SHA1-BASE64 use this function if no encoder is provided.")
 
 ;;; ----------------------------------------------------
 
@@ -160,9 +165,10 @@
 
 ;;; ----------------------------------------------------
 
-(defun sha1-base64 (message)
+(defun sha1-base64 (message &optional (base64-encoder *base64-encoder*))
   "Return the SHA1 base64-encoded digest for a byte sequence."
-  (base64-encode (map 'string #'code-char (sha1-digest message))))
+  (check-type base64-encoder function)
+  (funcall base64-encoder (map 'string #'code-char (sha1-digest message))))
 
 ;;; ----------------------------------------------------
 
@@ -198,6 +204,7 @@
 
 ;;; ----------------------------------------------------
 
-(defun hmac-sha1-base64 (key message)
+(defun hmac-sha1-base64 (key message &optional (base64-encoder *base64-encoder*))
   "Return the HMAC-SHA1 base64-encoded digest for a byte sequence."
-  (base64-encode (map 'string #'code-char (hmac-sha1-digest key message))))
+  (check-type base64-encoder function)
+  (funcall base64-encoder (map 'string #'code-char (hmac-sha1-digest key message))))

--- a/sha1.lisp
+++ b/sha1.lisp
@@ -33,6 +33,9 @@
 
 ;;; ----------------------------------------------------
 
+(deftype function-designator ()
+  '(or function symbol))
+
 (defvar *base64-encoder* nil
   "SHA1-BASE64 and HMAC-SHA1-BASE64 use this function if no encoder is provided.")
 
@@ -167,7 +170,7 @@
 
 (defun sha1-base64 (message &optional (base64-encoder *base64-encoder*))
   "Return the SHA1 base64-encoded digest for a byte sequence."
-  (check-type base64-encoder function)
+  (check-type base64-encoder function-designator)
   (funcall base64-encoder (map 'string #'code-char (sha1-digest message))))
 
 ;;; ----------------------------------------------------
@@ -206,5 +209,5 @@
 
 (defun hmac-sha1-base64 (key message &optional (base64-encoder *base64-encoder*))
   "Return the HMAC-SHA1 base64-encoded digest for a byte sequence."
-  (check-type base64-encoder function)
+  (check-type base64-encoder function-designator)
   (funcall base64-encoder (map 'string #'code-char (hmac-sha1-digest key message))))


### PR DESCRIPTION
Fixes #6.

Potential dependents were unable to load this library because its
dependency, massung/base64, has a package name conflict with cl-base64,
a popular implementation with over 50 dependents in Quicklisp at this
time.

This change removes the tight coupling by providing a couple avenues for
consumers to pass their own base64 encoder. They may either pass it
directly into the function, or dynamically bind `*base64-encoder*`:

```lisp
;; Using massung/base64:
(sha1-base64 "The quick brown fox jumps over the lazy dog."
             #'base64:base64-encode)

;; Using cl-base64:
(sha1-base64 "The quick brown fox jumps over the lazy dog."
             #'cl-base64:string-to-base64-string)

;; Or either, with a dynamic bind to *base64-encoder*:
(let ((*base64-encoder* #'base64:base64-encode))
  (sha1-base64 "The quick brown fox jumps over the lazy dog."))
```